### PR TITLE
Added the pool level support to set qos limits for lvol

### DIFF
--- a/include/spdk/bdev.h
+++ b/include/spdk/bdev.h
@@ -668,6 +668,58 @@ void spdk_bdev_set_qos_rate_limits(struct spdk_bdev *bdev, uint64_t *limits,
 				   void (*cb_fn)(void *cb_arg, int status), void *cb_arg);
 
 /**
+ * Set the quality of service rate limits on all the bdev. Used when setting the limits on poll level.
+ *
+ * \param bdev Block device.
+ * \param limits Pointer to the QoS rate limits array which holding the limits.
+ * \param qos_pool_id_object Pointer to the pool node.
+ * \param qos_bdev_node Pointer to the bdev in the pool for which setting the limits.
+ * \param bdev_node_cout Total number of bdevs in the pool.
+ * \param total_bdev_to_process Total number of bdevs to process in the pool.
+ * \param is_remove_bdev_request Set when the request is to remove the bdev from pool.
+ * \param **remove_bdev_list List of bdevs to remove from the pool.
+ * \param cb_fn Callback function to be called when the QoS limit has been updated.
+ * \param cb_arg Argument to pass to cb_fn.
+ *
+ * The limits are ordered based on the @ref spdk_bdev_qos_rate_limit_type enum.
+ */
+void
+spdk_bdev_set_qos_rate_limits_ex(struct spdk_bdev *bdev, uint64_t *limits, uint64_t bdev_pool_id,
+					void * qos_pool_id_object, void * qos_bdev_node, uint64_t bdev_node_cout,
+					uint64_t total_bdev_to_process, bool is_remove_bdev_request, char **remove_bdev_list,
+			    	void (*cb_fn)(void *cb_arg, int status), void *cb_arg);
+
+/**
+ * Set the quality of service rate limits on a bdev.
+ *
+ * \param bdev_pool_id Group ID
+ * \param limits Pointer to the QoS rate limits array which holding the limits.
+ * \param cb_fn Callback function to be called when the QoS limit has been updated.
+ * \param cb_arg Argument to pass to cb_fn.
+ *
+ * The limits are ordered based on the @ref spdk_bdev_qos_rate_limit_type enum.
+ */
+void
+spdk_bdev_set_qos_rate_limits_to_group(uint64_t bdev_pool_id, uint64_t *limits, 
+					void (*cb_fn)(void *cb_arg, int status), void *cb_arg);
+
+/**
+ * Set the quality of service rate limits on a bdev.
+ *
+ * \param bdev_pool_id Group ID
+ * \param num_bdevs Number of bdev to add/remove to/from the group.
+ * \param **names Names of the bdev to add/remove to/from the group.
+ * \param is_remove_bdev_request True of the request is to remove the bdevd from the group.
+ * \param cb_fn Callback function to be called when the QoS limit has been updated.
+ * \param cb_arg Argument to pass to cb_fn.
+ *
+ * The limits are ordered based on the @ref spdk_bdev_qos_rate_limit_type enum.
+ */
+void
+spdk_bdev_add_remove_bdev_to_pool(uint64_t bdev_pool_id, uint64_t num_bdevs, char	**names, 
+					bool is_remove_bdev_request, void (*cb_fn)(void *cb_arg, int status), void *cb_arg);
+
+/**
  * Get minimum I/O buffer address alignment for a bdev.
  *
  * \param bdev Block device to query.

--- a/include/spdk/priority_class.h
+++ b/include/spdk/priority_class.h
@@ -1,7 +1,7 @@
 #ifndef SPDK_PRIORITY_CLASS_H
 #define SPDK_PRIORITY_CLASS_H
 
-#define NBITS_PRIORITY_CLASS 4
+#define NBITS_PRIORITY_CLASS 3
 /* shift priority class value left by this to get the OR-mask or shift right by this after applying the priority 
 class mask PRIORITY_CLASS_MASK to get the priority class as an integer
 */
@@ -10,6 +10,7 @@ class mask PRIORITY_CLASS_MASK to get the priority class as an integer
 #define MASK_OUT_PRIORITY_CLASS (0xFFFFFFFFFFFFFFFF >> NBITS_PRIORITY_CLASS)
 #define MIN_PRIORITY_CLASS 0
 // #define MAX_PRIORITY_CLASS ((1 << NBITS_PRIORITY_CLASS) - 1)
-#define MAX_PRIORITY_CLASS 1
+#define MAX_PRIORITY_CLASS 7
+#define PREMIUM_PRIORITY_CLASS  1
 
 #endif

--- a/lib/bdev/bdev.c
+++ b/lib/bdev/bdev.c
@@ -189,7 +189,8 @@ struct spdk_bdev_qos_limit {
 
 struct spdk_bdev_qos {
 	/** Types of structure of rate limits. */
-	struct spdk_bdev_qos_limit rate_limits[SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES];
+	//struct spdk_bdev_qos_limit rate_limits[SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES];
+	struct spdk_bdev_qos_limit *rate_limits;
 
 	/** The channel that all I/O are funneled through. */
 	struct spdk_bdev_channel *ch;
@@ -205,7 +206,30 @@ struct spdk_bdev_qos {
 
 	/** Poller that processes queued I/O commands each time slice. */
 	struct spdk_poller *poller;
+
+	/** Refrence count for the qos object. Used incase of appling the limit on group of bdevs. */
+	uint32_t ref_count;
 };
+
+struct qos_bdev_list_node {
+	struct spdk_bdev *bdev;
+	char 	*bdev_name;
+	TAILQ_ENTRY(qos_bdev_list_node)	link;
+};
+
+struct spdk_bdev_qos_pool_id_mapping {
+	uint64_t bdev_pool_id;
+	TAILQ_HEAD(, qos_bdev_list_node) bdev_list;
+	uint64_t bdev_list_size;
+	// rate_limits is common to multiple bdev. Can we accessed by multiple threads. So we need to protect it.
+	struct spdk_bdev_qos_limit *rate_limits;
+	// Stores the actual limits set by rpc.
+	uint64_t	limits[SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES];
+	TAILQ_ENTRY(spdk_bdev_qos_pool_id_mapping)	link;
+};
+
+static TAILQ_HEAD(, spdk_bdev_qos_pool_id_mapping) g_qos_bdev_group_list = TAILQ_HEAD_INITIALIZER(g_qos_bdev_group_list);
+uint32_t g_qos_limit_update_pending_count = 0;
 
 struct spdk_bdev_mgmt_channel {
 	/*
@@ -368,6 +392,14 @@ struct set_qos_limit_ctx {
 	void (*cb_fn)(void *cb_arg, int status);
 	void *cb_arg;
 	struct spdk_bdev *bdev;
+	struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object;
+	struct qos_bdev_list_node *qos_bdev_node;
+	uint64_t	bdev_node_cout;
+	uint64_t	total_bdev_to_process;
+	uint64_t	bdev_pool_id;
+	bool		internal_request;
+	bool		is_remove_requets;
+	char		*remove_bdev_names[255];
 };
 
 struct spdk_bdev_channel_iter {
@@ -437,6 +469,17 @@ static void bdev_desc_release_claims(struct spdk_bdev_desc *desc);
 static void claim_reset(struct spdk_bdev *bdev);
 
 static void bdev_ch_retry_io(struct spdk_bdev_channel *bdev_ch);
+
+static void remove_bdev_from_group(char *bdev_names);
+static void delete_rate_limit(char *bdev_names, struct spdk_bdev_qos *qos);
+static bool is_bdev_exist_in_pool(char *bdev_names);
+static struct qos_bdev_list_node * find_existing_bdev(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, char *bdev_names);
+static int check_bdev_names_in_group(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, size_t num_lvols,char **bdev_names);
+static int check_bdev_name_in_group(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, char *bdev_names);
+static int check_bdev_exists(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, uint64_t num_bdevs, char   **bdev_names);
+static int add_bdev_list(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, uint64_t num_bdevs, char   **bdev_names);
+static struct spdk_bdev_qos_pool_id_mapping * create_qos_object_for_group(uint64_t bdev_pool_id);
+static struct spdk_bdev_qos_pool_id_mapping * get_qos_already_available_for_group(uint64_t bdev_pool_id);
 
 #define bdev_get_ext_io_opt(opts, field, defval) \
 	((opts) != NULL ? SPDK_GET_FIELD(opts, field, defval) : (defval))
@@ -3884,7 +3927,6 @@ bdev_enable_qos(struct spdk_bdev *bdev, struct spdk_bdev_channel *ch)
 			io_ch = spdk_get_io_channel(__bdev_to_io_dev(bdev));
 			assert(io_ch != NULL);
 			qos->ch = ch;
-
 			qos->thread = spdk_io_channel_get_thread(io_ch);
 
 			for (i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
@@ -4291,8 +4333,8 @@ bdev_qos_channel_destroy(void *cb_arg)
 	spdk_poller_unregister(&qos->poller);
 
 	SPDK_DEBUGLOG(bdev, "Free QoS %p.\n", qos);
-
 	free(qos);
+	qos = NULL;
 }
 
 static int
@@ -4322,7 +4364,6 @@ bdev_qos_destroy(struct spdk_bdev *bdev)
 
 	/* Copy the old QoS data into the newly allocated structure */
 	memcpy(new_qos, old_qos, sizeof(*new_qos));
-
 	/* Zero out the key parts of the QoS structure */
 	new_qos->ch = NULL;
 	new_qos->thread = NULL;
@@ -4340,7 +4381,10 @@ bdev_qos_destroy(struct spdk_bdev *bdev)
 	bdev->internal.qos = new_qos;
 
 	if (old_qos->thread == NULL) {
+		delete_rate_limit(bdev->name, old_qos);
+		remove_bdev_from_group(bdev->name);
 		free(old_qos);
+		old_qos = NULL;
 	} else {
 		spdk_thread_send_msg(old_qos->thread, bdev_qos_channel_destroy, old_qos);
 	}
@@ -7774,7 +7818,10 @@ bdev_destroy_cb(void *io_device)
 	cb_arg = bdev->internal.unregister_ctx;
 
 	spdk_spin_destroy(&bdev->internal.spinlock);
+	delete_rate_limit(bdev->name, bdev->internal.qos);
+	remove_bdev_from_group(bdev->name);
 	free(bdev->internal.qos);
+	bdev->internal.qos = NULL;
 	bdev_free_io_stat(bdev->internal.stat);
 	spdk_trace_unregister_owner(bdev->internal.trace_id);
 
@@ -9132,17 +9179,314 @@ bdev_write_zero_buffer_done(struct spdk_bdev_io *bdev_io, bool success, void *cb
 	parent_io->internal.cb(parent_io, success, parent_io->internal.caller_ctx);
 }
 
+static bool is_bdev_exist_in_pool(char *bdev_names) {
+	struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object = NULL;
+	struct qos_bdev_list_node *bdev_node = NULL;
+
+	TAILQ_FOREACH(qos_pool_id_object, &g_qos_bdev_group_list, link) {
+		TAILQ_FOREACH(bdev_node, &qos_pool_id_object->bdev_list, link) {
+			if (strcmp(bdev_node->bdev_name, bdev_names) == 0) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+static void delete_rate_limit(char *bdev_names, struct spdk_bdev_qos *qos) {
+
+	struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object = NULL;
+	struct qos_bdev_list_node *bdev_node = NULL;
+
+	TAILQ_FOREACH(qos_pool_id_object, &g_qos_bdev_group_list, link) {
+		TAILQ_FOREACH(bdev_node, &qos_pool_id_object->bdev_list, link) {
+        	if (strcmp(bdev_node->bdev_name, bdev_names) == 0) {
+            	return;
+        	}
+    	}
+	}
+	if(qos) {
+		if(qos->rate_limits != NULL) {
+			free(qos->rate_limits);
+			qos->rate_limits = NULL;
+		}
+	}
+	
+	return;
+}
+
+
+static void remove_bdev_from_group(char *bdev_names) {
+
+	struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object = NULL;
+	struct qos_bdev_list_node *bdev_node = NULL;
+
+	if (TAILQ_EMPTY(&g_qos_bdev_group_list)) {
+            return ;
+    }
+	TAILQ_FOREACH(qos_pool_id_object, &g_qos_bdev_group_list, link) {
+		TAILQ_FOREACH(bdev_node, &qos_pool_id_object->bdev_list, link) {
+        	if (strcmp(bdev_node->bdev_name, bdev_names) == 0) {
+				SPDK_NOTICELOG("Removing the bdev from list: %s vs %s\n", bdev_node->bdev_name, bdev_names);
+				TAILQ_REMOVE(&qos_pool_id_object->bdev_list, bdev_node, link);
+				if(bdev_node->bdev_name) {
+					free(bdev_node->bdev_name);
+					bdev_node->bdev_name = NULL;
+				}
+				if(bdev_node) {
+					free(bdev_node);
+					bdev_node = NULL;
+				}
+				--qos_pool_id_object->bdev_list_size;
+
+				if(qos_pool_id_object->bdev_list_size == 0) {
+					SPDK_NOTICELOG("Cleaning the group mapping for group %"PRIu64"\n",qos_pool_id_object->bdev_pool_id);
+					if(qos_pool_id_object->rate_limits != NULL) {
+						SPDK_NOTICELOG("Cleaning the rate limit\n");
+						free(qos_pool_id_object->rate_limits);
+						qos_pool_id_object->rate_limits = NULL;
+					}
+					TAILQ_REMOVE(&g_qos_bdev_group_list, qos_pool_id_object, link);
+					if(qos_pool_id_object) {
+						free(qos_pool_id_object);
+						qos_pool_id_object = NULL;
+					}
+				}
+            	return;
+        	}
+    	}
+	}
+	return;
+}
+
+static struct qos_bdev_list_node * find_existing_bdev(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, char *bdev_names) {
+	struct qos_bdev_list_node *bdev_node = NULL;
+	if(qos_pool_id_object == NULL || bdev_names == NULL){
+		return NULL;
+	}
+
+	TAILQ_FOREACH(bdev_node, &qos_pool_id_object->bdev_list, link) {
+        if (strcmp(bdev_node->bdev_name, bdev_names) == 0) {
+            /* Found a matching bdev name in existing list */
+            return bdev_node;
+        }
+    }
+	return bdev_node;
+}
+
+
+static int check_bdev_names_in_group(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, 
+								size_t num_lvols,
+                               char **bdev_names)
+{
+    struct qos_bdev_list_node *bdev_node;
+    size_t i, found_count = 0;
+
+    if (qos_pool_id_object == NULL || bdev_names == NULL || num_lvols == 0) {
+        return -1;
+    }
+
+    for (i = 0; i < num_lvols; i++) {
+        TAILQ_FOREACH(bdev_node, &qos_pool_id_object->bdev_list, link) {
+            if (strcmp(bdev_node->bdev_name, bdev_names[i]) == 0) {
+                found_count++;
+                break;
+            }
+        }
+    }
+    return (found_count == num_lvols) ? 0 : -1;
+}
+
+static int check_bdev_name_in_group(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, 
+                               char *bdev_names)
+{
+    struct qos_bdev_list_node *bdev_node = NULL;
+    size_t found_count = 0;
+
+    if (qos_pool_id_object == NULL || bdev_names == NULL) {
+        return -1;
+    }
+        TAILQ_FOREACH(bdev_node, &qos_pool_id_object->bdev_list, link) {
+            if (strcmp(bdev_node->bdev_name, bdev_names) == 0) {
+                found_count++;
+                break;
+            }
+    }
+
+    return found_count;
+}
+
+static int check_bdev_exists(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, uint64_t num_bdevs, char	**bdev_names) {
+
+	struct qos_bdev_list_node *bdev_node = NULL;
+	if(qos_pool_id_object == NULL || bdev_names == NULL){
+		return -1;
+	}
+    /* First check if any of the new bdev names already exist in the list */
+    TAILQ_FOREACH(bdev_node, &qos_pool_id_object->bdev_list, link) {
+        for (uint64_t i = 0; i < num_bdevs; i++) {
+            if (strcmp(bdev_node->bdev_name, bdev_names[i]) == 0) {
+                /* Found a duplicate name in existing list */
+                return -1;
+            }
+        }
+    }
+
+	/* Now check for duplicates within the new bdev names array */
+    for (uint64_t i = 0; i < num_bdevs - 1; i++) {
+        for (uint64_t j = i + 1; j < num_bdevs; j++) {
+            if (strcmp(bdev_names[i], bdev_names[j]) == 0) {
+                /* Found a duplicate name in new names */
+                return -1;
+            }
+        }
+    }
+
+	return 0;
+}
+
+static int add_bdev_list(struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_object, uint64_t num_bdevs, char	**bdev_names) {
+
+	struct qos_bdev_list_node *bdev_node = NULL;
+	if(qos_pool_id_object == NULL || bdev_names == NULL) {
+		return -1;
+	}
+	for (uint64_t i = 0; i < num_bdevs ; i++) {
+		bdev_node = (struct qos_bdev_list_node *)calloc(1, sizeof(struct qos_bdev_list_node));
+		if(bdev_node == NULL) {
+			return -1;
+		}
+		bdev_node->bdev_name = strdup(bdev_names[i]);
+		TAILQ_INSERT_TAIL(&qos_pool_id_object->bdev_list, bdev_node,link);
+		++qos_pool_id_object->bdev_list_size;
+	}
+	return 0;
+}
+
+static struct spdk_bdev_qos_pool_id_mapping * create_qos_object_for_group(uint64_t bdev_pool_id)	{
+	struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_mapping_node = NULL;
+
+	qos_pool_id_mapping_node = (struct spdk_bdev_qos_pool_id_mapping *)calloc(1, sizeof(struct spdk_bdev_qos_pool_id_mapping));
+	if(qos_pool_id_mapping_node == NULL)
+	{
+		SPDK_ERRLOG("No memory. \n");
+		return NULL;
+	}
+
+	qos_pool_id_mapping_node->bdev_pool_id = bdev_pool_id;
+	TAILQ_INIT(&qos_pool_id_mapping_node->bdev_list);
+	qos_pool_id_mapping_node->bdev_list_size = 0;
+	qos_pool_id_mapping_node->rate_limits = NULL;
+	TAILQ_INSERT_TAIL(&g_qos_bdev_group_list, qos_pool_id_mapping_node, link);
+	return qos_pool_id_mapping_node;
+}
+
+// Find the qos pointed for the bdev_pool_id from the list qos_pool_id_mapping_node.
+static struct spdk_bdev_qos_pool_id_mapping * get_qos_already_available_for_group(uint64_t bdev_pool_id) {
+	struct spdk_bdev_qos_pool_id_mapping *qos_pool_id_mapping_node = NULL;
+
+	TAILQ_FOREACH(qos_pool_id_mapping_node, &g_qos_bdev_group_list, link) {
+		if(qos_pool_id_mapping_node->bdev_pool_id == bdev_pool_id) {
+			return qos_pool_id_mapping_node;
+		}
+	}
+	return NULL;
+}
+
+static void
+dummy_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev, void *ctx)
+{
+}
+
 static void
 bdev_set_qos_limit_done(struct set_qos_limit_ctx *ctx, int status)
 {
+	struct qos_bdev_list_node *next_qos_bdev_node = NULL;
+	struct spdk_bdev_desc *desc;
+	int rc = 0;
+	uint64_t	limits[SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES];
+	char		*tmp_remove_bdev_names[255] = {NULL};
 	spdk_spin_lock(&ctx->bdev->internal.spinlock);
 	ctx->bdev->internal.qos_mod_in_progress = false;
 	spdk_spin_unlock(&ctx->bdev->internal.spinlock);
-
-	if (ctx->cb_fn) {
-		ctx->cb_fn(ctx->cb_arg, status);
+	SPDK_NOTICELOG("Set qos limit done for %s\n", ctx->bdev->name);
+	if(ctx->internal_request == true)
+	{
+		if(ctx->total_bdev_to_process > ctx->bdev_node_cout) {
+			if(ctx->is_remove_requets == true) {
+				remove_bdev_from_group(ctx->qos_bdev_node->bdev_name);
+				next_qos_bdev_node = find_existing_bdev(ctx->qos_pool_id_object, ctx->remove_bdev_names[ctx->bdev_node_cout]);
+				// Copy the limits in the transient variable.
+				for (uint64_t i = 0; i < ctx->total_bdev_to_process; i++) {
+					tmp_remove_bdev_names[i] = strdup(ctx->remove_bdev_names[i]);
+				}
+				// Copy the limits in the transient variable.
+				for (int i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
+					limits[i] = 0;
+				}
+			} else {
+				next_qos_bdev_node = TAILQ_NEXT(ctx->qos_bdev_node, link);
+				// Copy the limits in the transient variable.
+				for (uint64_t i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
+					limits[i] = ctx->qos_pool_id_object->limits[i];
+				}
+			}
+			// This case is not possible.
+			if(next_qos_bdev_node == NULL) {
+				ctx->cb_fn(ctx->cb_arg, 0);
+				free(ctx);
+				ctx = NULL;
+				return;
+			}
+			rc = spdk_bdev_open_ext(next_qos_bdev_node->bdev_name, false, dummy_bdev_event_cb, NULL, &desc);
+				if (rc != 0) {
+					SPDK_ERRLOG("Failed to open bdev '%s': %d\n", next_qos_bdev_node->bdev_name, rc);
+					ctx->cb_fn(ctx->cb_arg, -ENXIO);
+					free(ctx);
+					ctx = NULL;
+					return;
+				}
+			
+			spdk_bdev_set_qos_rate_limits_ex(spdk_bdev_desc_get_bdev(desc), limits, ctx->bdev_pool_id, ctx->qos_pool_id_object, 
+			next_qos_bdev_node, ++ctx->bdev_node_cout, ctx->total_bdev_to_process ,ctx->is_remove_requets, tmp_remove_bdev_names, ctx->cb_fn, ctx->cb_arg);
+			spdk_bdev_close(desc);
+			
+			if(ctx->is_remove_requets) {
+				for(uint64_t i = 0 ; i < ctx->total_bdev_to_process; i++) {
+					if(ctx->remove_bdev_names[i] != NULL) {
+						free(ctx->remove_bdev_names[i]);
+					}
+				}
+				for (uint64_t i = 0; i < ctx->total_bdev_to_process; i++) {
+					free(tmp_remove_bdev_names[i]);
+				}
+			}
+			free(ctx);
+		} else {
+			// End of the the nodes
+			if(ctx->is_remove_requets) {
+				remove_bdev_from_group(ctx->qos_bdev_node->bdev_name);
+				for(uint64_t i = 0 ; i < ctx->total_bdev_to_process; i++) {
+					if(ctx->remove_bdev_names[i] != NULL) {
+						free(ctx->remove_bdev_names[i]);
+					}
+				}
+			}
+			ctx->cb_fn(ctx->cb_arg,0);
+			free(ctx);
+		}
+	} else {
+		if(ctx->is_remove_requets) {
+				for(uint64_t i = 0 ; i < ctx->total_bdev_to_process; i++) {
+					if(ctx->remove_bdev_names[i] != NULL) {
+						free(ctx->remove_bdev_names[i]);
+					}
+				}
+			}
+		ctx->cb_fn(ctx->cb_arg,0);
+		free(ctx);
 	}
-	free(ctx);
+	return;
 }
 
 static void
@@ -9162,7 +9506,18 @@ bdev_disable_qos_done(void *cb_arg)
 		spdk_poller_unregister(&qos->poller);
 	}
 
+	//When processing the request for the pool.
+	if ( ctx->internal_request == true && check_bdev_name_in_group(ctx->qos_pool_id_object, ctx->qos_bdev_node->bdev_name) != 0)
+	{
+		if (ctx->is_remove_requets == true) {
+			free(qos->rate_limits);
+		}
+	} else {
+		free(qos->rate_limits);
+	}
+	qos->rate_limits = NULL;
 	free(qos);
+	qos = NULL;
 
 	bdev_set_qos_limit_done(ctx, 0);
 }
@@ -9206,6 +9561,7 @@ bdev_disable_qos_msg(struct spdk_bdev_channel_iter *i, struct spdk_bdev *bdev,
 static void
 bdev_update_qos_rate_limit_msg(void *cb_arg)
 {
+
 	struct set_qos_limit_ctx *ctx = cb_arg;
 	struct spdk_bdev *bdev = ctx->bdev;
 
@@ -9232,7 +9588,6 @@ static void
 bdev_enable_qos_done(struct spdk_bdev *bdev, void *_ctx, int status)
 {
 	struct set_qos_limit_ctx *ctx = _ctx;
-
 	bdev_set_qos_limit_done(ctx, status);
 }
 
@@ -9242,11 +9597,9 @@ bdev_set_qos_rate_limits(struct spdk_bdev *bdev, uint64_t *limits)
 	int i;
 
 	assert(bdev->internal.qos != NULL);
-
 	for (i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
 		if (limits[i] != SPDK_BDEV_QOS_LIMIT_NOT_DEFINED) {
 			bdev->internal.qos->rate_limits[i].limit = limits[i];
-
 			if (limits[i] == 0) {
 				bdev->internal.qos->rate_limits[i].limit =
 					SPDK_BDEV_QOS_LIMIT_NOT_DEFINED;
@@ -9295,6 +9648,12 @@ spdk_bdev_set_qos_rate_limits(struct spdk_bdev *bdev, uint64_t *limits,
 			SPDK_ERRLOG("Round up the rate limit to %" PRIu64 "\n", limits[i]);
 		}
 	}
+	// Do not allow to set the limits if bdev is part of the pool.
+	if(is_bdev_exist_in_pool(bdev->name) == true) {
+		SPDK_ERRLOG("bdev %s exist in pool. Remove the bdev from pool before setting independent limits.\n", bdev->name);
+		cb_fn(cb_arg, -EPERM);
+		return;
+	}
 
 	ctx = calloc(1, sizeof(*ctx));
 	if (ctx == NULL) {
@@ -9305,6 +9664,7 @@ spdk_bdev_set_qos_rate_limits(struct spdk_bdev *bdev, uint64_t *limits,
 	ctx->cb_fn = cb_fn;
 	ctx->cb_arg = cb_arg;
 	ctx->bdev = bdev;
+	ctx->internal_request = false;
 
 	spdk_spin_lock(&bdev->internal.spinlock);
 	if (bdev->internal.qos_mod_in_progress) {
@@ -9331,6 +9691,13 @@ spdk_bdev_set_qos_rate_limits(struct spdk_bdev *bdev, uint64_t *limits,
 		if (bdev->internal.qos == NULL) {
 			bdev->internal.qos = calloc(1, sizeof(*bdev->internal.qos));
 			if (!bdev->internal.qos) {
+				spdk_spin_unlock(&bdev->internal.spinlock);
+				SPDK_ERRLOG("Unable to allocate memory for QoS tracking\n");
+				bdev_set_qos_limit_done(ctx, -ENOMEM);
+				return;
+			}
+			bdev->internal.qos->rate_limits = calloc(SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES, sizeof(struct spdk_bdev_qos_limit));
+			if (!bdev->internal.qos->rate_limits) {
 				spdk_spin_unlock(&bdev->internal.spinlock);
 				SPDK_ERRLOG("Unable to allocate memory for QoS tracking\n");
 				bdev_set_qos_limit_done(ctx, -ENOMEM);
@@ -9366,6 +9733,338 @@ spdk_bdev_set_qos_rate_limits(struct spdk_bdev *bdev, uint64_t *limits,
 	}
 
 	spdk_spin_unlock(&bdev->internal.spinlock);
+}
+
+void
+spdk_bdev_set_qos_rate_limits_to_group(uint64_t bdev_pool_id, uint64_t *limits, 
+					void (*cb_fn)(void *cb_arg, int status), void *cb_arg) {
+
+	int					rc = 0;
+	struct qos_bdev_list_node * qos_bdev_node = NULL;
+	struct spdk_bdev_desc *desc;
+	struct spdk_bdev_qos_pool_id_mapping * qos_pool_id_object = NULL;
+
+
+	if(bdev_pool_id <= 0)
+	{
+		cb_fn(cb_arg, -EPERM);
+		return;
+	}
+
+	qos_pool_id_object = get_qos_already_available_for_group(bdev_pool_id);
+	if(qos_pool_id_object == NULL) {
+		SPDK_ERRLOG("Group ID %" PRIu64 " not available.\n", bdev_pool_id);
+		cb_fn(cb_arg, -EPERM);
+		return;
+	}
+
+	if(qos_pool_id_object->bdev_list_size <= 0) {
+		SPDK_ERRLOG("Bdev list empty for Group ID %" PRIu64 " vs %" PRIu64 "\n", bdev_pool_id, qos_pool_id_object->bdev_list_size);
+		cb_fn(cb_arg, -EPERM);
+		return;
+	}
+
+	qos_bdev_node = TAILQ_FIRST(&qos_pool_id_object->bdev_list);
+
+	rc = spdk_bdev_open_ext(qos_bdev_node->bdev_name, false, dummy_bdev_event_cb, NULL, &desc);
+	if (rc != 0) {
+		SPDK_ERRLOG("Failed to open bdev '%s': %d\n", qos_bdev_node->bdev_name, rc);
+		cb_fn(cb_arg, -EPERM);
+		return;
+	}
+	// Copy the limits for future use.
+	for (int i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
+		qos_pool_id_object->limits[i] = limits[i];
+	}
+	spdk_bdev_set_qos_rate_limits_ex(spdk_bdev_desc_get_bdev(desc), limits, bdev_pool_id, qos_pool_id_object, qos_bdev_node,
+							1, qos_pool_id_object->bdev_list_size, false, NULL, cb_fn, cb_arg);
+	spdk_bdev_close(desc);
+	return;
+}
+
+void
+spdk_bdev_set_qos_rate_limits_ex(struct spdk_bdev *bdev, uint64_t *limits, uint64_t bdev_pool_id,
+					void * qos_pool_id_object, void * qos_bdev_node, uint64_t bdev_node_cout,
+					uint64_t total_bdev_to_process, 
+					bool is_remove_bdev_request, char **remove_bdev_list,
+			    	void (*cb_fn)(void *cb_arg, int status), void *cb_arg) {
+	struct set_qos_limit_ctx	*ctx;
+	uint32_t			limit_set_complement;
+	uint64_t			min_limit_per_sec;
+	uint64_t				i;
+	bool				disable_rate_limit = true;
+	bool set_limits = false;
+	struct spdk_bdev_qos_limit *tmp_rate_limits;
+
+
+	struct spdk_bdev_qos_pool_id_mapping * qos_pool_id_object_l = qos_pool_id_object;
+	
+	SPDK_NOTICELOG("Setting the limits qos limits for bdev %s group id %" PRIu64 "\n",bdev->name, bdev_pool_id);
+	if(bdev_pool_id <= 0)
+	{
+		cb_fn(cb_arg, -EPERM);
+		return;
+	}
+	ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		cb_fn(cb_arg, -ENOMEM);
+		return;
+	}
+
+	ctx->cb_fn = cb_fn;
+	ctx->cb_arg = cb_arg;
+	ctx->bdev = bdev;
+	ctx->bdev_pool_id = bdev_pool_id;
+	ctx->qos_bdev_node = qos_bdev_node;
+	ctx->qos_pool_id_object = qos_pool_id_object;
+	ctx->bdev_node_cout = bdev_node_cout;
+	ctx->is_remove_requets = is_remove_bdev_request;
+	ctx->total_bdev_to_process = total_bdev_to_process;
+
+	for (i = 0; i <255; i++){
+		ctx->remove_bdev_names[i] = NULL;
+	}
+	
+	// This is used for appling the limits at pool level.
+	ctx->internal_request = true;
+
+	for (i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
+		if (limits[i] == SPDK_BDEV_QOS_LIMIT_NOT_DEFINED) {
+			continue;
+		}
+
+		if (limits[i] > 0) {
+			disable_rate_limit = false;
+		}
+
+		if (bdev_qos_is_iops_rate_limit(i) == true) {
+			min_limit_per_sec = SPDK_BDEV_QOS_MIN_IOS_PER_SEC;
+		} else {
+			if (limits[i] > SPDK_BDEV_QOS_MAX_MBYTES_PER_SEC) {
+				SPDK_WARNLOG("Requested rate limit %" PRIu64 " will result in uint64_t overflow, "
+					     "reset to %" PRIu64 "\n", limits[i], SPDK_BDEV_QOS_MAX_MBYTES_PER_SEC);
+				limits[i] = SPDK_BDEV_QOS_MAX_MBYTES_PER_SEC;
+			}
+			/* Change from megabyte to byte rate limit */
+			limits[i] = limits[i] * 1024 * 1024;
+			min_limit_per_sec = SPDK_BDEV_QOS_MIN_BYTES_PER_SEC;
+		}
+
+		limit_set_complement = limits[i] % min_limit_per_sec;
+		if (limit_set_complement) {
+			SPDK_ERRLOG("Requested rate limit %" PRIu64 " is not a multiple of %" PRIu64 "\n",
+				    limits[i], min_limit_per_sec);
+			limits[i] += min_limit_per_sec - limit_set_complement;
+			SPDK_ERRLOG("Round up the rate limit to %" PRIu64 "\n", limits[i]);
+		}
+	}
+
+	spdk_spin_lock(&bdev->internal.spinlock);
+	if (bdev->internal.qos_mod_in_progress) {
+		spdk_spin_unlock(&bdev->internal.spinlock);
+		free(ctx);
+		cb_fn(cb_arg, -EAGAIN);
+		return;
+	}
+	bdev->internal.qos_mod_in_progress = true;
+
+	if (disable_rate_limit == true && bdev->internal.qos) {
+		for (i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
+			if (limits[i] == SPDK_BDEV_QOS_LIMIT_NOT_DEFINED &&
+			    (bdev->internal.qos->rate_limits[i].limit > 0 &&
+			     bdev->internal.qos->rate_limits[i].limit !=
+			     SPDK_BDEV_QOS_LIMIT_NOT_DEFINED)) {
+				disable_rate_limit = false;
+				break;
+			}
+		}
+	}
+
+	if (disable_rate_limit == false) {
+		if (bdev->internal.qos == NULL) {
+			bdev->internal.qos = calloc(1, sizeof(*bdev->internal.qos));
+			if (!bdev->internal.qos) {
+				spdk_spin_unlock(&bdev->internal.spinlock);
+				SPDK_ERRLOG("Unable to allocate memory for QoS tracking\n");
+				free(ctx);
+				cb_fn(cb_arg, -ENOMEM);
+				return;
+			}
+			set_limits = true;
+			// Set the rate_limit to NULl for future validation.
+			bdev->internal.qos->rate_limits = NULL;
+		}
+
+		if(qos_pool_id_object_l->rate_limits == NULL) {
+			SPDK_NOTICELOG("Creating the rate_limit pointer \n");
+			qos_pool_id_object_l->rate_limits = calloc(SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES, sizeof(struct spdk_bdev_qos_limit));
+			if (qos_pool_id_object_l->rate_limits == NULL) {
+				SPDK_ERRLOG("Unable to allocate memory for QoS tracking\n");
+				spdk_spin_unlock(&bdev->internal.spinlock);
+				free(ctx);
+				cb_fn(cb_arg, -ENOMEM);
+				return;
+			}
+		}
+		// Assining the common rate limit pointer.
+		if(bdev->internal.qos->rate_limits != NULL)
+		{
+			SPDK_NOTICELOG("Swapping the rate limits with group rate limits 1\n");
+			if (bdev->internal.qos->rate_limits != qos_pool_id_object_l->rate_limits) {
+				SPDK_NOTICELOG("Swapping the rate limits with group rate limits 2\n");
+				tmp_rate_limits = bdev->internal.qos->rate_limits;
+				bdev->internal.qos->rate_limits = qos_pool_id_object_l->rate_limits;
+				free(tmp_rate_limits);
+				tmp_rate_limits = NULL;
+			}
+		} else {
+			SPDK_NOTICELOG("Assining the qos rate limits.\n");
+			bdev->internal.qos->rate_limits = qos_pool_id_object_l->rate_limits;
+		}
+		
+		
+		if (bdev->internal.qos->thread == NULL) {
+			/* Enabling */
+			SPDK_NOTICELOG("ENEBLING the limits for bdev %s\n", bdev->name);
+			if(set_limits == true) {
+				SPDK_NOTICELOG("Setting the limits for group %" PRIu64 "\n", bdev_pool_id);
+				bdev_set_qos_rate_limits(bdev, limits);
+			}
+
+			spdk_bdev_for_each_channel(bdev, bdev_enable_qos_msg, ctx,
+						   bdev_enable_qos_done);
+		} else {
+			SPDK_NOTICELOG("UPDATING the limits for bdev %s\n", bdev->name);
+			/* Updating */
+			
+			if(is_remove_bdev_request == true) {
+				// Replace the rate_limits with new memory to make sure the group limits are intact.
+				bdev->internal.qos->rate_limits = calloc(SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES, sizeof(struct spdk_bdev_qos_limit));
+				// Remove the bdev from the group.
+				if(remove_bdev_list != NULL) {
+					for (i = 0; i < total_bdev_to_process ; i++) {
+						ctx->remove_bdev_names[i] = strdup(remove_bdev_list[i]);
+					}
+				}
+			}
+			bdev_set_qos_rate_limits(bdev, limits);
+
+			spdk_thread_send_msg(bdev->internal.qos->thread,
+					     bdev_update_qos_rate_limit_msg, ctx);
+		}
+	} else {
+		if (bdev->internal.qos != NULL) {
+			SPDK_NOTICELOG("DISABLING the limits for bdev %s\n", bdev->name);
+			if(is_remove_bdev_request == true) {
+				// Replace the rate_limits with new memory to make sure the group limits are intact.
+				bdev->internal.qos->rate_limits = calloc(SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES, sizeof(struct spdk_bdev_qos_limit));
+				if(remove_bdev_list != NULL) {
+					for (i = 0; i < total_bdev_to_process ; i++) {
+						ctx->remove_bdev_names[i] = strdup(remove_bdev_list[i]);
+					}
+				}
+			}
+			bdev_set_qos_rate_limits(bdev, limits);
+
+			/* Disabling */
+			spdk_bdev_for_each_channel(bdev, bdev_disable_qos_msg, ctx,
+						   bdev_disable_qos_msg_done);
+		} else {
+			spdk_spin_unlock(&bdev->internal.spinlock);
+			bdev_set_qos_limit_done(ctx, 0);
+			return;
+		}
+	}
+
+	spdk_spin_unlock(&bdev->internal.spinlock);
+}
+
+
+void
+spdk_bdev_add_remove_bdev_to_pool(uint64_t bdev_pool_id, uint64_t num_bdevs, char	**bdev_names, bool is_remove_bdev_request,
+					void (*cb_fn)(void *cb_arg, int status), void *cb_arg)	{
+	struct spdk_bdev_qos_pool_id_mapping * qos_pool_id_object = NULL;
+	struct qos_bdev_list_node * qos_bdev_list_node = NULL;
+	struct spdk_bdev_desc *desc;
+	int rc = 0, temp_bdev_count_in_list = 0;
+	uint64_t	limits[SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES];
+	qos_pool_id_object = get_qos_already_available_for_group(bdev_pool_id);
+	// Object for the group id not yet created.
+	if(is_remove_bdev_request == false) {
+		if(qos_pool_id_object == NULL) {
+			SPDK_NOTICELOG("Creating mapping object for group id : %" PRIu64 "\n", bdev_pool_id);
+			qos_pool_id_object = create_qos_object_for_group(bdev_pool_id);
+			add_bdev_list(qos_pool_id_object, num_bdevs, bdev_names);
+		} else {
+			if (check_bdev_exists(qos_pool_id_object, num_bdevs, bdev_names) == 0)
+			{
+				temp_bdev_count_in_list = qos_pool_id_object->bdev_list_size;
+				add_bdev_list(qos_pool_id_object, num_bdevs, bdev_names);
+			} else {
+				// Return error as one of the lvol is already in the group.
+				cb_fn(cb_arg, -EINVAL);
+				return;
+			}
+		}
+
+		if (qos_pool_id_object->rate_limits != NULL) {
+			// Limits are already set so need to set the limits to newly added lvols.
+			// Iterate to the first newly added first lvol.
+			qos_bdev_list_node = find_existing_bdev(qos_pool_id_object, bdev_names[0]);
+			if(qos_bdev_list_node)
+			{
+				rc = spdk_bdev_open_ext(qos_bdev_list_node->bdev_name, false, dummy_bdev_event_cb, NULL, &desc);
+				if (rc != 0) {
+					SPDK_ERRLOG("Failed to open bdev '%s': %d\n", qos_bdev_list_node->bdev_name, rc);
+					cb_fn(cb_arg, -EINVAL);
+					return;
+				}
+				// Copy the original values of the transient variable.
+				for (int i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
+					limits[i] = qos_pool_id_object->limits[i];
+				}
+				spdk_bdev_set_qos_rate_limits_ex(spdk_bdev_desc_get_bdev(desc), limits, bdev_pool_id, qos_pool_id_object, qos_bdev_list_node,
+								++temp_bdev_count_in_list, qos_pool_id_object->bdev_list_size, false, NULL, cb_fn, cb_arg);
+				spdk_bdev_close(desc);
+			}
+		} else {
+			cb_fn(cb_arg, 0);
+			return;
+		}
+	}
+	else {
+		if(qos_pool_id_object == NULL) {
+			cb_fn(cb_arg, -EINVAL);
+		} else {
+			if (check_bdev_names_in_group(qos_pool_id_object, num_bdevs, bdev_names) == 0) {
+				qos_bdev_list_node = find_existing_bdev(qos_pool_id_object, bdev_names[0]);
+				if(qos_bdev_list_node) {
+				
+					rc = spdk_bdev_open_ext(qos_bdev_list_node->bdev_name, false, dummy_bdev_event_cb, NULL, &desc);
+					if (rc != 0) {
+						SPDK_ERRLOG("Failed to open bdev '%s': %d\n", qos_bdev_list_node->bdev_name, rc);
+						cb_fn(cb_arg, -EINVAL);
+						return;
+					}
+					// disable the limits for the bdev
+					for (int i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
+						// Set this to 0
+						limits[i] = 0;
+					}
+					spdk_bdev_set_qos_rate_limits_ex(spdk_bdev_desc_get_bdev(desc), limits, bdev_pool_id, qos_pool_id_object, qos_bdev_list_node,
+								1, num_bdevs, is_remove_bdev_request, bdev_names, cb_fn, cb_arg);
+					spdk_bdev_close(desc);
+				}
+				else {
+					// Very unlikely
+					cb_fn(cb_arg, -EINVAL);
+				}
+			} else {
+				cb_fn(cb_arg, -EINVAL);
+			}
+		}
+	}
+	return;
 }
 
 struct spdk_bdev_histogram_ctx {

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -14070,7 +14070,7 @@ void
 spdk_blob_set_io_priority_class(struct spdk_blob* blob, int priority_class)
 {
 	blob->priority_class = priority_class;
-	if (priority_class) { blob->bs->priority_class = MAX_PRIORITY_CLASS; } // max priority for metadata I/O if priority is supported
+	if (priority_class) { blob->bs->priority_class = PREMIUM_PRIORITY_CLASS; } // max priority for metadata I/O if priority is supported
 }
 
 SPDK_LOG_REGISTER_COMPONENT(blob)

--- a/module/bdev/lvol/vbdev_lvol_rpc.c
+++ b/module/bdev/lvol/vbdev_lvol_rpc.c
@@ -14,6 +14,7 @@
 #include "spdk/json.h"
 
 SPDK_LOG_REGISTER_COMPONENT(lvol_rpc)
+#define RPC_MAX_LVOL_VBDEV 255
 
 struct rpc_shallow_copy_status {
 	uint32_t				operation_id;
@@ -2840,3 +2841,303 @@ cleanup:
 
 SPDK_RPC_REGISTER("bdev_lvol_set_priority_class", rpc_bdev_lvol_set_priority_class,
 		  SPDK_RPC_RUNTIME)
+
+static void
+dummy_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev, void *ctx)
+{
+}
+
+struct rpc_vbdev_lvol_set_qos_limit {
+	uint64_t	bdev_group_id;
+	uint64_t	limits[SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES];
+};
+
+static void
+free_rpc_vbdev_lvol_set_qos_limit(struct rpc_vbdev_lvol_set_qos_limit *r)
+{
+}
+
+static const struct spdk_json_object_decoder rpc_vbdev_lvol_set_qos_limit_decoders[] = {
+	{"bdev_group_id", offsetof(struct rpc_vbdev_lvol_set_qos_limit, 
+						bdev_group_id), 
+		spdk_json_decode_uint64,true},
+	{
+		"rw_ios_per_sec", offsetof(struct rpc_vbdev_lvol_set_qos_limit,
+					   limits[SPDK_BDEV_QOS_RW_IOPS_RATE_LIMIT]),
+		spdk_json_decode_uint64, true
+	},
+	{
+		"rw_mbytes_per_sec", offsetof(struct rpc_vbdev_lvol_set_qos_limit,
+					      limits[SPDK_BDEV_QOS_RW_BPS_RATE_LIMIT]),
+		spdk_json_decode_uint64, true
+	},
+	{
+		"r_mbytes_per_sec", offsetof(struct rpc_vbdev_lvol_set_qos_limit,
+					     limits[SPDK_BDEV_QOS_R_BPS_RATE_LIMIT]),
+		spdk_json_decode_uint64, true
+	},
+	{
+		"w_mbytes_per_sec", offsetof(struct rpc_vbdev_lvol_set_qos_limit,
+					     limits[SPDK_BDEV_QOS_W_BPS_RATE_LIMIT]),
+		spdk_json_decode_uint64, true
+	},
+};
+
+static void
+rpc_vbdev_lvol_set_qos_limit_complete(void *cb_arg, int status)
+{
+	struct spdk_jsonrpc_request *request = cb_arg;
+
+	if (status != 0) {
+		spdk_jsonrpc_send_error_response_fmt(request, SPDK_JSONRPC_ERROR_INVALID_PARAMS,
+						     "Failed to configure rate limit: %s",
+						     spdk_strerror(-status));
+		return;
+	}
+
+	spdk_jsonrpc_send_bool_response(request, true);
+}
+
+static void
+rpc_vbdev_lvol_set_qos_limit(struct spdk_jsonrpc_request *request,
+		       const struct spdk_json_val *params)
+{
+	struct rpc_vbdev_lvol_set_qos_limit req = {0, {UINT64_MAX, UINT64_MAX, UINT64_MAX, UINT64_MAX}};
+	int i;
+
+	if (spdk_json_decode_object(params, rpc_vbdev_lvol_set_qos_limit_decoders,
+				    SPDK_COUNTOF(rpc_vbdev_lvol_set_qos_limit_decoders),
+				    &req)) {
+		SPDK_ERRLOG("spdk_json_decode_object failed\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	for (i = 0; i < SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES; i++) {
+		if (req.limits[i] != UINT64_MAX) {
+			break;
+		}
+	}
+
+	if (i == SPDK_BDEV_QOS_NUM_RATE_LIMIT_TYPES) {
+		SPDK_ERRLOG("No rate limits specified\n");
+		spdk_jsonrpc_send_error_response(request, -EINVAL, "No rate limits specified");
+		goto cleanup;
+	}
+
+	// Group ID is compulsory for this RPC
+	if(req.bdev_group_id == 0)
+	{
+		SPDK_ERRLOG("No group ID specified.\n");
+		spdk_jsonrpc_send_error_response(request, -EINVAL, "No group ID specified");
+		goto cleanup;
+	}
+	spdk_bdev_set_qos_rate_limits_to_group(req.bdev_group_id, req.limits, rpc_vbdev_lvol_set_qos_limit_complete, request);
+
+cleanup:
+	free_rpc_vbdev_lvol_set_qos_limit(&req);
+}
+
+SPDK_RPC_REGISTER("bdev_lvol_set_qos_limit", rpc_vbdev_lvol_set_qos_limit, SPDK_RPC_RUNTIME)
+
+
+struct rpc_vbdev_lvol_name_list {
+	/* Number of lvol bdevs */
+	size_t	num_lvols;
+	/* List of lvol bdevs names */
+	char	*names[RPC_MAX_LVOL_VBDEV];
+};
+
+struct rpc_vbdev_lvol_add_to_group {
+	uint64_t	bdev_group_id;
+	/* List of lvol bdevs names */
+	struct rpc_vbdev_lvol_name_list  lvol_vbdev_list;
+};
+
+static void
+free_rpc_vbdev_lvol_add_to_group(struct rpc_vbdev_lvol_add_to_group *req)
+{
+	for (size_t i = 0; i < req->lvol_vbdev_list.num_lvols; i++) {
+		if(req->lvol_vbdev_list.names[i]) {
+			free(req->lvol_vbdev_list.names[i]);
+		}
+	}
+}
+static int
+decode_lvol_vbdev_names(const struct spdk_json_val *val, void *out)
+{
+	struct rpc_vbdev_lvol_name_list *lvols = out;
+	return spdk_json_decode_array(val, spdk_json_decode_string, lvols->names,
+				      RPC_MAX_LVOL_VBDEV, &lvols->num_lvols, sizeof(char *));
+}
+
+static const struct spdk_json_object_decoder rpc_vbdev_lvol_add_to_group_decoders[] = {
+	{"bdev_group_id", offsetof(struct rpc_vbdev_lvol_add_to_group, bdev_group_id), spdk_json_decode_uint64,},
+	{"lvol_vbdev_list", offsetof(struct rpc_vbdev_lvol_add_to_group, lvol_vbdev_list), decode_lvol_vbdev_names},
+};
+
+
+static void
+rpc_vbdev_lvol_add_to_group_complete(void *cb_arg, int status)
+{
+	struct spdk_jsonrpc_request *request = cb_arg;
+	if (status != 0) {
+		spdk_jsonrpc_send_error_response_fmt(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						     "Failed to configure rate limit: %s",
+						     spdk_strerror(-status));
+		return;
+	}
+
+	spdk_jsonrpc_send_bool_response(request, true);
+}
+
+static void
+rpc_vbdev_lvol_add_to_group(struct spdk_jsonrpc_request *request,
+		       const struct spdk_json_val *params)
+{
+	struct rpc_vbdev_lvol_add_to_group req;
+	struct spdk_bdev_desc *desc;
+	size_t i = 0;
+	int rc;
+	char	*unique_bdev_name[RPC_MAX_LVOL_VBDEV];
+	struct spdk_bdev * bdev = NULL;
+	
+	// Initilize the char array.
+	for (i = 0; i < RPC_MAX_LVOL_VBDEV; i++) {
+		req.lvol_vbdev_list.names[i] = NULL;
+		unique_bdev_name[i] = NULL;
+	}
+
+	if (spdk_json_decode_object(params, rpc_vbdev_lvol_add_to_group_decoders,
+				    SPDK_COUNTOF(rpc_vbdev_lvol_add_to_group_decoders),
+				    &req)) {
+		SPDK_ERRLOG("spdk_json_decode_object failed\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	// Validate the list of lvols.
+	for (i = 0; i < req.lvol_vbdev_list.num_lvols; i++) {
+		rc = spdk_bdev_open_ext(req.lvol_vbdev_list.names[i], false, dummy_bdev_event_cb, NULL, &desc);
+		if (rc != 0) {
+			SPDK_ERRLOG("Failed to open bdev '%s': %d\n", req.lvol_vbdev_list.names[i], rc);
+			spdk_jsonrpc_send_error_response(request, rc, spdk_strerror(-rc));
+			goto cleanup;
+		}
+		bdev = spdk_bdev_desc_get_bdev(desc);
+		if(bdev->internal.qos != NULL) {
+			SPDK_ERRLOG("Qos limits already set for lvol: '%s'. Please disable the limits before adding to the group.\n", req.lvol_vbdev_list.names[i]);
+			spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR, "Failed to add lvol to pool: Operation not permitted");
+			spdk_bdev_close(desc);
+			goto cleanup;
+		}
+		unique_bdev_name[i] = strdup(bdev->name);
+		spdk_bdev_close(desc);
+	}
+
+	spdk_bdev_add_remove_bdev_to_pool(req.bdev_group_id, req.lvol_vbdev_list.num_lvols, unique_bdev_name, false,
+					rpc_vbdev_lvol_add_to_group_complete,request);
+cleanup:
+	// Free the transient variable.
+	for (i = 0; i < req.lvol_vbdev_list.num_lvols; i++) {
+		if(unique_bdev_name[i]) {
+			free(unique_bdev_name[i]);
+		}
+	}
+	free_rpc_vbdev_lvol_add_to_group(&req);
+}
+
+SPDK_RPC_REGISTER("bdev_lvol_add_to_group", rpc_vbdev_lvol_add_to_group, SPDK_RPC_RUNTIME)
+
+
+/*******************/
+
+struct rpc_vbdev_lvol_remove_from_group {
+	uint64_t	bdev_group_id;
+	/* List of lvol bdevs names */
+	struct rpc_vbdev_lvol_name_list  lvol_vbdev_list;
+};
+
+static void
+free_rpc_vbdev_lvol_remove_from_group(struct rpc_vbdev_lvol_remove_from_group *req)
+{
+	for (size_t i = 0; i < req->lvol_vbdev_list.num_lvols; i++) {
+		if(req->lvol_vbdev_list.names[i]) {
+			free(req->lvol_vbdev_list.names[i]);
+		}
+	}
+}
+
+static const struct spdk_json_object_decoder rpc_vbdev_lvol_remove_from_group_decoders[] = {
+	{"bdev_group_id", offsetof(struct rpc_vbdev_lvol_remove_from_group, bdev_group_id), spdk_json_decode_uint64,},
+	{"lvol_vbdev_list", offsetof(struct rpc_vbdev_lvol_remove_from_group, lvol_vbdev_list), decode_lvol_vbdev_names},
+};
+
+
+static void
+rpc_vbdev_lvol_remove_from_group_complete(void *cb_arg, int status)
+{
+	struct spdk_jsonrpc_request *request = cb_arg;
+	if (status != 0) {
+		spdk_jsonrpc_send_error_response_fmt(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						     "Failed to configure rate limit: %s",
+						     spdk_strerror(-status));
+		return;
+	}
+
+	spdk_jsonrpc_send_bool_response(request, true);
+}
+
+static void
+rpc_vbdev_lvol_remove_from_group(struct spdk_jsonrpc_request *request,
+		       const struct spdk_json_val *params)
+{
+	struct rpc_vbdev_lvol_remove_from_group req;
+	struct spdk_bdev_desc *desc;
+	size_t i = 0;
+	int rc;
+	char	*unique_bdev_name[RPC_MAX_LVOL_VBDEV];
+	
+	// Initilize the char array.
+	for (i = 0; i < RPC_MAX_LVOL_VBDEV; i++) {
+		req.lvol_vbdev_list.names[i] = NULL;
+		unique_bdev_name[i] = NULL;
+	}
+
+	if (spdk_json_decode_object(params, rpc_vbdev_lvol_remove_from_group_decoders,
+				    SPDK_COUNTOF(rpc_vbdev_lvol_remove_from_group_decoders),
+				    &req)) {
+		SPDK_ERRLOG("spdk_json_decode_object failed\n");
+		spdk_jsonrpc_send_error_response(request, SPDK_JSONRPC_ERROR_INTERNAL_ERROR,
+						 "spdk_json_decode_object failed");
+		goto cleanup;
+	}
+
+	// Validate the list of lvols.
+	for (i = 0; i < req.lvol_vbdev_list.num_lvols; i++) {
+		rc = spdk_bdev_open_ext(req.lvol_vbdev_list.names[i], false, dummy_bdev_event_cb, NULL, &desc);
+		if (rc != 0) {
+			SPDK_ERRLOG("Failed to open bdev '%s': %d\n", req.lvol_vbdev_list.names[i], rc);
+			spdk_jsonrpc_send_error_response(request, rc, spdk_strerror(-rc));
+			goto cleanup;
+		}
+
+		unique_bdev_name[i] = strdup(spdk_bdev_desc_get_bdev(desc)->name);
+		spdk_bdev_close(desc);
+	}
+
+	spdk_bdev_add_remove_bdev_to_pool(req.bdev_group_id, req.lvol_vbdev_list.num_lvols, unique_bdev_name, true,
+					rpc_vbdev_lvol_remove_from_group_complete,request);
+cleanup:
+	// Free the transient variable.
+	for (i = 0; i < req.lvol_vbdev_list.num_lvols; i++) {
+		if(unique_bdev_name[i]) {
+			free(unique_bdev_name[i]);
+		}
+	}
+	free_rpc_vbdev_lvol_remove_from_group(&req);
+}
+
+SPDK_RPC_REGISTER("bdev_lvol_remove_from_group", rpc_vbdev_lvol_remove_from_group, SPDK_RPC_RUNTIME)


### PR DESCRIPTION
    1. Added the RPC to add/remove the lvols to/from pool.
    2. Added RPC to et the QoS limits at pool level.
    3. Before setting the limits at pool level limits the lvol needs to added to the pool. Same RPC is used to disable the qos limits. Use the limits value 0 to disable the limits. Again enabling the limits can be done on the group with valid limit values.
    4. When lvol is deleted the bdev is removed from the pool.
    5. When all the lvols in the pool are deleted the pool is also deleted so next time when new lvols are added the set limits on the group should be invoked.
    6. Tested the code using the unit test exec_test_rate_limit.
    7. Tested the code with ASAN build as well.
    8. Restricted to set qos limits when lvol is part of pool and vice a versa.
    9. Added the support of all 7 priority classes in lvol