### PR TITLE
Update OpenSSL to 3.5.7 in SPDK base Dockerfile

### DIFF
--- a/docker/Dockerfile_spdk_base
+++ b/docker/Dockerfile_spdk_base
@@ -21,12 +21,12 @@ RUN rm -rf /root/spdk
 RUN dnf update -y && dnf upgrade -y && \
     dnf install -y zlib-devel make gcc perl curl \
     libcurl-devel libuuid-devel pulseaudio-libs-devel && \
-    wget https://www.openssl.org/source/openssl-3.5.6.tar.gz && \
-    tar -xvf openssl-3.5.6.tar.gz && \
-    cd openssl-3.5.6 && \
+    wget https://www.openssl.org/source/openssl-3.5.7.tar.gz && \
+    tar -xvf openssl-3.5.7.tar.gz && \
+    cd openssl-3.5.7 && \
     ./config && make -j"$(nproc)" && make install && \
     echo /usr/local/lib64 > /etc/ld.so.conf.d/openssl.conf && ldconfig && \
-    cd .. && rm -rf openssl-3.5.6*
+    cd .. && rm -rf openssl-3.5.7*
 
 # Clone + build AWS SDK
 RUN git clone --recurse-submodules https://github.com/simplyblock-io/aws-sdk-cpp && \


### PR DESCRIPTION
## Summary
- The ultra repo's security scan (https://github.com/simplyblock/ultra/actions/runs/29477579791/job/87553808322) flagged OpenSSL 3.5.6 for several High/Critical CVEs (CVE-2026-45447, CVE-2026-42764, CVE-2026-34180, CVE-2026-34183, CVE-2026-34182, etc.).
- `ultra`'s `Dockerfile_spdk_ultra` builds FROM `simplyblock/spdk-core:nvmf-blocking-from-base-latest`, which is built from this branch's `docker/Dockerfile_spdk_base`.
- `master`'s `Dockerfile_spdk_base` was already bumped to OpenSSL 3.5.7 (d090dffe0), but this `nvmf-blocking-from-base` branch's copy was missed and still pins 3.5.6.
- Bumps to 3.5.7, matching the master fix, so the base image (and everything built from it, including ultra) picks up the patched OpenSSL.

## Test plan
- [ ] `Docker Base Image Build` workflow on this branch builds/pushes successfully
- [ ] ultra's security scan passes once the refreshed base image is published