### PR TITLE
lvol/blob: hold client IO across leadership promotion; demote candidates on writer conflict

### DIFF
--- a/include/spdk/blob.h
+++ b/include/spdk/blob.h
@@ -469,6 +469,21 @@ void spdk_blob_update_failed_cleanup(struct spdk_blob *blob,
 				 spdk_blob_op_complete cb_fn, void *cb_arg);
 
 void spdk_bs_set_leader(struct spdk_blob_store *bs, bool state);
+
+/**
+ * Hold (queue) all user blob IO submitted to this blobstore while a
+ * leadership promotion is being confirmed. Held ops are released by
+ * spdk_bs_flush_held_io() after the hold is cleared: they execute when
+ * the blobstore is leader, otherwise they fail with -EIO (callers are
+ * expected to block the NVMf ports first in that case).
+ */
+void spdk_bs_set_promotion_hold(struct spdk_blob_store *bs, bool hold);
+
+/**
+ * Flush ops queued while promotion_hold was set (skips ops belonging to
+ * blobs that are still frozen — their unfreeze flushes them).
+ */
+void spdk_bs_flush_held_io(struct spdk_blob_store *bs);
 void spdk_bs_set_role(struct spdk_blob_store *bs, node_role_t role);
 node_role_t node_role_from_string(const char *str);
 const char *node_role_to_string(node_role_t role);

--- a/lib/blob/blobstore.c
+++ b/lib/blob/blobstore.c
@@ -3863,8 +3863,11 @@ blob_request_submit_op_single(struct spdk_io_channel *_ch, struct spdk_blob *blo
 	cpl.u.blob_basic.cb_fn = cb_fn;
 	cpl.u.blob_basic.cb_arg = cb_arg;
 
-	if (blob->frozen_refcnt) {
-		/* This blob I/O is frozen */
+	if (blob->frozen_refcnt || blob->bs->promotion_hold) {
+		/* This blob I/O is frozen, or the store is a promotion
+		 * candidate whose leadership is not yet confirmed — hold the
+		 * IO instead of appending it to the journal pre-confirmation
+		 * (a premature append is a writer conflict waiting to happen). */
 		spdk_bs_user_op_t *op;
 		struct spdk_bs_channel *bs_channel = spdk_io_channel_get_ctx(_ch);
 
@@ -4215,8 +4218,10 @@ blob_request_submit_rw_iov(struct spdk_blob *blob, struct spdk_io_channel *_chan
 		cpl.u.blob_basic.cb_fn = cb_fn;
 		cpl.u.blob_basic.cb_arg = cb_arg;
 
-		if (blob->frozen_refcnt) {
-			/* This blob I/O is frozen */
+		if (blob->frozen_refcnt || blob->bs->promotion_hold) {
+			/* This blob I/O is frozen, or the store is a promotion
+			 * candidate whose leadership is not yet confirmed — hold
+			 * the IO (see blob_request_submit_op_single). */
 			enum spdk_blob_op_type op_type;
 			spdk_bs_user_op_t *op;
 			struct spdk_bs_channel *bs_channel = spdk_io_channel_get_ctx(_channel);
@@ -7983,7 +7988,75 @@ spdk_bs_get_super(struct spdk_blob_store *bs,
 void
 spdk_bs_set_leader(struct spdk_blob_store *bs, bool state)
 {
-	bs->is_leader = state;	
+	bs->is_leader = state;
+}
+
+void
+spdk_bs_set_promotion_hold(struct spdk_blob_store *bs, bool hold)
+{
+	if (bs->promotion_hold != hold) {
+		SPDK_NOTICELOG("Promotion hold %s.\n", hold ? "engaged" : "released");
+	}
+	bs->promotion_hold = hold;
+}
+
+struct bs_held_io_ctx {
+	struct spdk_blob_store *bs;
+};
+
+static void
+bs_flush_held_io_channel(struct spdk_io_channel_iter *i)
+{
+	struct spdk_io_channel *_ch = spdk_io_channel_iter_get_channel(i);
+	struct spdk_bs_channel *ch = spdk_io_channel_get_ctx(_ch);
+	struct bs_held_io_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+	struct spdk_blob_store *bs = ctx->bs;
+	struct spdk_bs_request_set	*set;
+	struct spdk_bs_user_op_args	*args;
+	spdk_bs_user_op_t *op, *tmp;
+
+	TAILQ_FOREACH_SAFE(op, &ch->queued_io, link, tmp) {
+		set = (struct spdk_bs_request_set *)op;
+		args = &set->u.user_op;
+
+		if (args->blob->frozen_refcnt > 0) {
+			/* Still frozen for a blob md update: the blob's own
+			 * unfreeze flushes these. */
+			continue;
+		}
+		TAILQ_REMOVE(&ch->queued_io, op, link);
+		if (bs->is_leader && !args->blob->failed_on_update) {
+			bs_user_op_execute(op);
+		} else {
+			SPDK_NOTICELOG("The IO return with EIO error due to leader or failed update.\n");
+			bs_user_op_abort(op, -EIO);
+		}
+	}
+
+	spdk_for_each_channel_continue(i, 0);
+}
+
+static void
+bs_flush_held_io_cpl(struct spdk_io_channel_iter *i, int status)
+{
+	struct bs_held_io_ctx *ctx = spdk_io_channel_iter_get_ctx(i);
+
+	free(ctx);
+}
+
+void
+spdk_bs_flush_held_io(struct spdk_blob_store *bs)
+{
+	struct bs_held_io_ctx *ctx;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		SPDK_ERRLOG("Cannot allocate ctx to flush held IO.\n");
+		return;
+	}
+	ctx->bs = bs;
+
+	spdk_for_each_channel(bs, bs_flush_held_io_channel, ctx, bs_flush_held_io_cpl);
 }
 
 void

--- a/lib/blob/blobstore.h
+++ b/lib/blob/blobstore.h
@@ -217,6 +217,15 @@ struct spdk_blob_store {
 	 * Only when the distrib internal force state changes, it will be set to false.
 	 */
 	bool				is_leader;
+	/* True while a leadership failover (promotion) is being confirmed.
+	 * User blob IO submitted while set is queued on the channel
+	 * (same queued_io list the per-blob freeze uses) instead of being
+	 * executed — a promotion candidate must not append client IO to the
+	 * journal before its leadership is confirmed, and must not fail it
+	 * while confirmation is still in progress. Released via
+	 * spdk_bs_set_promotion_hold(false) + spdk_bs_flush_held_io().
+	 */
+	bool				promotion_hold;
 	node_role_t 		node_role;
 	bool				read_only;
 	bool 				stop;

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -2716,12 +2716,24 @@ lvol_update_on_failover(struct spdk_lvol_store *lvs, struct spdk_lvol *lvol, boo
 	}
 }
 
+static void spdk_lvs_promotion_give_up(struct spdk_lvol_store *lvs);
+
 static void
 lvs_update_on_failover_cpl(void *cb_arg, int lvolerrno)
 {
 	struct spdk_lvs_req *req = (struct spdk_lvs_req *)cb_arg;
 	struct spdk_lvol_store *lvs = req->lvol_store;
 	struct spdk_lvol *lvol, *tmp;
+
+	/* A writer-conflict demotion that landed while this update was in
+	 * flight cancelled the promotion and blocked the ports — a late
+	 * SUCCESS completion must not re-claim leadership behind it. */
+	if (lvolerrno == 0 && !lvs->update_in_progress) {
+		SPDK_NOTICELOG("Lvolstore failover update completed after demotion; ignoring.\n");
+		free(req);
+		return;
+	}
+
 	if (lvolerrno == 0) {
 		spdk_lvs_set_leader(lvs, true);
 		lvs->timeout_trigger = 0;
@@ -2737,23 +2749,56 @@ lvs_update_on_failover_cpl(void *cb_arg, int lvolerrno)
 	}
 
 	SPDK_ERRLOG("Cannot update lvolstore on failover ...\n");
+
+	/* A concurrent writer-conflict demotion cancelled this promotion
+	 * (spdk_lvs_change_leader_state set update_in_progress=false) and
+	 * owns the cleanup: ports are blocked and the conflict unfreeze
+	 * flushes the held queues. Do not retry, double-clean, or escalate
+	 * to abort() for an update the conflict already invalidated (the
+	 * conflict sets timeout_trigger=1, which would otherwise trip the
+	 * abort below for a mid-flight completion). */
+	if (!lvs->update_in_progress) {
+		free(req);
+		return;
+	}
+
 	if (lvolerrno == -ENOTCONN || (lvolerrno != 0 && lvs->timeout_trigger == 1)) {
     	SPDK_ERRLOG("Failed to update lvolstore during failover due to distrib-level functionality.\n");
     	SPDK_ERRLOG("Forcing application shutdown via abort.\n");
 		// Ensure all log messages are flushed
     	fflush(stderr);
 		abort();
-	}	
+	}
+
+	if (lvs->retry_on_update <= 3) {
+		/* Retries remain: keep client IO held (promotion_hold) and
+		 * frozen blobs frozen, and retry the update in place. The old
+		 * behavior flushed every queued IO with EIO on EVERY failed
+		 * attempt — during a 2.5 s contended failover that surfaced
+		 * thousands of non-retryable INTERNAL DEVICE ERRORs to
+		 * initiators (scale-break 2026-07-16). */
+		lvs->retry_on_update++;
+		SPDK_NOTICELOG("Retrying lvolstore failover update (attempt %d); held IO stays queued.\n",
+			       lvs->retry_on_update);
+		req->poller = spdk_poller_register(spdk_lvs_update_on_failover_poller, req, 500000); // Delay of 500ms
+		return;
+	}
+
+	/* Retry budget exhausted: fail closed. Block the LVS ports FIRST so
+	 * the EIO completions from the queue flush die behind the block (the
+	 * initiator sees the path go away and retries elsewhere) instead of
+	 * reaching connected clients as non-retryable device errors. */
+	spdk_lvs_promotion_give_up(lvs);
 	spdk_lvs_set_failed_on_update(lvs, true);
 	//remember call function to drop the IO for this lvol
 	TAILQ_FOREACH_SAFE(lvol, &lvs->pending_update_lvols, entry_to_update, tmp) {
 		TAILQ_REMOVE(&lvs->pending_update_lvols, lvol, entry_to_update);
 		assert(lvol->update_in_progress == true);
 		lvol->failed_on_update = true;
-		spdk_blob_update_failed_cleanup(lvol->blob, lvol_update_failed_cpl, lvol);		
+		spdk_blob_update_failed_cleanup(lvol->blob, lvol_update_failed_cpl, lvol);
 	}
 	free(req);
-	return;	
+	return;
 }
 
 static int
@@ -2761,6 +2806,12 @@ spdk_lvs_update_on_failover_poller(void *cb_arg)
 {
 	struct spdk_lvs_req *req = cb_arg;
 	spdk_poller_unregister(&req->poller);
+	if (!req->lvol_store->update_in_progress) {
+		/* Promotion was cancelled (writer-conflict demotion) between
+		 * arming and firing; the conflict path owns the cleanup. */
+		free(req);
+		return -1;
+	}
 	SPDK_NOTICELOG("Update lvolstore starting.... read super block.\n");
 	spdk_bs_update_on_failover(req->lvol_store->blobstore, lvs_update_on_failover_cpl, req);
 	return -1;
@@ -3450,11 +3501,57 @@ spdk_lvs_remove_rules_poller(void *cb_arg)
 	return -1;
 }
 
+/* Promotion failed permanently (retry budget exhausted): fail closed.
+ * Block the LVS data port (and reject the hublvol port for non-tertiary
+ * roles) BEFORE the held/frozen queues are flushed, so the resulting EIO
+ * completions die behind the block — the initiator sees the path drop and
+ * retries on another path — instead of reaching live client connections as
+ * non-retryable device errors. Mirrors the writer-conflict demotion
+ * sequence in spdk_lvs_unfreeze_on_conflict(). */
+static void
+spdk_lvs_promotion_give_up(struct spdk_lvol_store *lvs)
+{
+	struct spdk_lvs_req *req;
+
+	SPDK_ERRLOG("Lvolstore %s promotion failed permanently; blocking ports and releasing held IO.\n",
+		    node_role_to_string(lvs->node_role));
+
+	pthread_mutex_lock(&g_lvol_stores_mutex);
+	block_port(lvs->subsystem_port);
+
+	if (lvs->node_role != NODE_TERTIARY && lvs->hublvol_port != 0) {
+		add_reject_hublvol_port(lvs->hublvol_port);
+		req = calloc(1, sizeof(*req));
+		if (req == NULL) {
+			SPDK_ERRLOG("Cannot alloc memory for request structure\n");
+			// in this case we should not wait for the IO inflyight
+			remove_reject_hublvol_port(lvs->hublvol_port);
+		} else {
+			req->lvol_store = lvs;
+			req->poller = spdk_poller_register(spdk_lvs_remove_rules_poller, req, 10000000); // Delay of 10s
+		}
+	}
+
+	lvs->leadership_timeout = spdk_get_ticks();
+	lvs->timeout_trigger = 1;
+	lvs->leader = false;
+	lvs->retry_on_update = 0;
+	spdk_bs_set_leader(lvs->blobstore, false);
+	pthread_mutex_unlock(&g_lvol_stores_mutex);
+
+	/* Held (never-frozen) ops flush as EIO behind the blocked port; ops
+	 * queued against still-frozen blobs are flushed by the per-blob
+	 * update_failed_cleanup that follows in the caller. */
+	spdk_bs_set_promotion_hold(lvs->blobstore, false);
+	spdk_bs_flush_held_io(lvs->blobstore);
+}
+
 static void
 spdk_lvs_unfreeze_on_conflict(struct spdk_lvol_store *lvs)
 {
-	struct spdk_lvol *lvol;
+	struct spdk_lvol *lvol, *tmp_lvol;
 	struct spdk_lvs_req *req;
+	TAILQ_HEAD(, spdk_lvol) pending = TAILQ_HEAD_INITIALIZER(pending);
 
 	pthread_mutex_lock(&g_lvol_stores_mutex);
 	block_port(lvs->subsystem_port);
@@ -3490,8 +3587,32 @@ spdk_lvs_unfreeze_on_conflict(struct spdk_lvol_store *lvs)
 		lvol->update_in_progress = false;
 	}
 
+	/* Cancel a candidate's promotion-pending lvols: their per-lvol
+	 * updates never ran, so (a) leaving them listed double-inserts on
+	 * the next promotion, and (b) their blob_freeze_on_failover refcnt
+	 * is released by nobody else (the conflict unfreeze below only
+	 * drops the conflict-freeze reference). Drain the list here and
+	 * clean each entry after the lock drops. */
+	TAILQ_FOREACH_SAFE(lvol, &lvs->pending_update_lvols, entry_to_update, tmp_lvol) {
+		TAILQ_REMOVE(&lvs->pending_update_lvols, lvol, entry_to_update);
+		TAILQ_INSERT_TAIL(&pending, lvol, entry_to_update);
+	}
+
 	pthread_mutex_unlock(&g_lvol_stores_mutex);
 	spdk_lvs_dequeu_rsp(lvs);
+
+	TAILQ_FOREACH_SAFE(lvol, &pending, entry_to_update, tmp_lvol) {
+		TAILQ_REMOVE(&pending, lvol, entry_to_update);
+		lvol->failed_on_update = true;
+		spdk_blob_update_failed_cleanup(lvol->blob, lvol_update_failed_cpl, lvol);
+	}
+
+	/* If the conflict hit a promotion candidate, ops may be held by
+	 * promotion_hold on blobs that were never frozen — release and flush
+	 * them here (they abort as EIO behind the ports blocked above); the
+	 * frozen blobs' queues are flushed by the unfreeze below. */
+	spdk_bs_set_promotion_hold(lvs->blobstore, false);
+	spdk_bs_flush_held_io(lvs->blobstore);
 
 	SPDK_NOTICELOG("Starting unfreeze the lvols.\n");
 	spdk_lvs_unfreeze_on_conflict_msg(lvs->blobstore);
@@ -3532,7 +3653,7 @@ int
 spdk_lvs_change_leader_state(uint64_t groupid)
 {
 	struct spdk_lvol_store *lvs;
-	struct spdk_lvol *lvol;
+	struct spdk_lvol *lvol, *tmp_lvol;
 	struct spdk_lvs_req *req;
 	int rc = 0;
 	SPDK_NOTICELOG("Attempting to change leadership state internally groupid %" PRIu64 ".\n", groupid);
@@ -3587,6 +3708,23 @@ spdk_lvs_change_leader_state(uint64_t groupid)
 				}
 
 				spdk_lvs_dequeu_rsp(lvs);
+
+				/* ENOMEM fallback (freeze msg could not be sent):
+				 * drop promotion-pending entries so the next
+				 * promotion cannot double-insert them. Their
+				 * failover-freeze refs are not released here (no
+				 * md-thread context) — acceptable on this
+				 * allocation-failure path. */
+				TAILQ_FOREACH_SAFE(lvol, &lvs->pending_update_lvols, entry_to_update, tmp_lvol) {
+					TAILQ_REMOVE(&lvs->pending_update_lvols, lvol, entry_to_update);
+					lvol->failed_on_update = true;
+				}
+
+				/* Candidate demotion: release ops held by
+				 * promotion_hold (never-frozen blobs) behind the
+				 * ports blocked above. */
+				spdk_bs_set_promotion_hold(lvs->blobstore, false);
+				spdk_bs_flush_held_io(lvs->blobstore);
 			}
 			SPDK_NOTICELOG("Leadership state changed internally to false for lvs %s. Timeout has been set.\n", node_role_to_string(lvs->node_role));
 			rc = 1;
@@ -6477,6 +6615,16 @@ spdk_lvs_check_active_process(struct spdk_lvol_store *lvs, struct spdk_lvol *lvo
 		lvs->failed_on_update = false;
 		lvs->trigger_leader_sent = false;
 		lvs->retry_on_update++;
+		/* Hold user blob IO from this moment until the failover update
+		 * confirms (or permanently fails) the promotion. Without the
+		 * hold, IO accepted between this trigger and the update's blob
+		 * freezes (the 500 ms poller delay below, plus the first-write
+		 * race per lvol) executes against the journal from a node whose
+		 * leadership was never confirmed — the premature appends that
+		 * produce a writer conflict (scale-break 2026-07-16 23:44:22.6:
+		 * hub IO redirected to a just-triggered secondary passed
+		 * through unfrozen; conflict flagged at 23:44:22.960). */
+		spdk_bs_set_promotion_hold(lvs->blobstore, true);
 		spdk_bs_set_leader(lvs->blobstore, true);
 		SPDK_NOTICELOG("Lvolstore %s failover set poller - trigger refresh: %" PRIu64 " t %d \n", node_role_to_string(lvs->node_role), lvol->blob_id, type);
 		req->poller = spdk_poller_register(spdk_lvs_update_on_failover_poller, req, 500000); // Delay of 500ms
@@ -6497,6 +6645,13 @@ spdk_lvs_set_leader(struct spdk_lvol_store *lvs, bool leader)
 	lvs->retry_on_update = 0;
 
 	pthread_mutex_unlock(&g_lvol_stores_mutex);
+
+	/* Promotion resolved: release IO held since the trigger. With
+	 * leadership confirmed the held ops execute in order; on a demote
+	 * (leader=false) they abort behind the ports the demotion path
+	 * blocked. No-op when nothing is held. */
+	spdk_bs_set_promotion_hold(lvs->blobstore, false);
+	spdk_bs_flush_held_io(lvs->blobstore);
 }
 
 void

--- a/lib/lvol/lvol.c
+++ b/lib/lvol/lvol.c
@@ -3478,6 +3478,7 @@ spdk_lvs_unfreeze_on_conflict(struct spdk_lvol_store *lvs)
 
 	lvs->update_in_progress = false;
 	lvs->failed_on_update = false;
+	lvs->retry_on_update = 0;
 	lvs->leadership_timeout = spdk_get_ticks();
 	lvs->timeout_trigger = 1;
 	lvs->leader = false;
@@ -3537,7 +3538,18 @@ spdk_lvs_change_leader_state(uint64_t groupid)
 	SPDK_NOTICELOG("Attempting to change leadership state internally groupid %" PRIu64 ".\n", groupid);
 	pthread_mutex_lock(&g_lvol_stores_mutex);
 	TAILQ_FOREACH(lvs, &g_lvol_stores, link) {
-		if ((lvs->groupid == groupid || groupid == 0) && lvs->leader) {
+		/* A writer conflict must demote not only an ESTABLISHED leader
+		 * (lvs->leader) but also a promotion CANDIDATE mid-failover
+		 * (update_in_progress): the candidate has already flipped the
+		 * blobstore leader flag and may have journal appends in flight,
+		 * yet lvs->leader is still false until the failover update
+		 * completes. Skipping it here leaves its NVMf ports open during
+		 * the conflict, so the failed-update path flushes queued client
+		 * IO as EIO straight to connected initiators (scale-break
+		 * incident 2026-07-16 23:44: both survivors were candidates,
+		 * "total blocked ports: 0" for the whole event). */
+		if ((lvs->groupid == groupid || groupid == 0) &&
+		    (lvs->leader || lvs->update_in_progress)) {
 			lvs->queue_failed_rsp = true;
 			if (spdk_blob_freeze_on_conflict_send_msg(lvs->blobstore,
 					spdk_lvs_conflict_signal, lvs)) {
@@ -3562,6 +3574,7 @@ spdk_lvs_change_leader_state(uint64_t groupid)
 
 				lvs->update_in_progress = false;
 				lvs->failed_on_update = false;
+				lvs->retry_on_update = 0;
 				lvs->leadership_timeout = spdk_get_ticks();
 				lvs->timeout_trigger = 1;
 				lvs->leader = false;


### PR DESCRIPTION
## Problem

RCA of `k8s_native_scale_break` 2026-07-16 23:44 (graceful shutdown of an LVS primary under 64-pod load): a normal leadership failover turned into ~6,000 client-visible `INTERNAL DEVICE ERROR (00/06)` completions and ext4 journal aborts (filesystems remounted read-only) on 10 PVCs, within 3 seconds.

Root cause chain (validated against pod logs + this source):

1. **Pre-confirmation pass-through.** The accept-and-promote path on a non-leader (`vbdev_hublvol_submit_request` -> `spdk_lvs_check_active_process`) flips the blobstore leader flag immediately, but the confirming lvolstore update starts only after a 500 ms poller delay. Blob IO is queued solely on `frozen_refcnt`, so IO accepted in that window executes straight into the journal **from a node whose leadership was never confirmed**. The JC flags those premature appends as a writer conflict (observed at 23:44:22.960, before either survivor's update had started), which demotes the distribs (`b_block_new_io=1`) — blocking the very superblock write the confirmation update needs.
2. **Conflict handler skips candidates.** `spdk_lvs_change_leader_state()` gated its whole freeze -> `block_port` -> demote sequence on `lvs->leader`, so mid-promotion candidates were ignored: **no port block** (`total blocked ports: 0` throughout the incident on both survivors).
3. **Flush-on-failure.** Each failed confirmation attempt flushed the frozen queues with EIO (`spdk_blob_update_failed_cleanup` per pending lvol) — 4 attempts over 2.5 s, thousands of errors through open ports. As a non-path NVMe status, initiator multipath does not retry these; ext4 aborts its journal on the failed writes.

## Fix

**Commit 1 — demote promotion candidates on writer conflict.** `spdk_lvs_change_leader_state()` now matches `update_in_progress` stores in addition to established leaders, so a candidate gets the same freeze -> port-block -> demote treatment that makes established-leader conflicts invisible to clients. Retry state is reset in both conflict paths.

**Commit 2 — `promotion_hold`: hold client IO across the promotion.**
- New blobstore flag `promotion_hold`, engaged at the promotion trigger: user blob IO submitted while set is queued on the existing per-channel `queued_io` list (same mechanism as the per-blob freeze). No premature journal appends -> the conflict source of this incident is gone.
- Failed confirmation attempts now **retry in place** (500 ms, existing 4-attempt budget) with all IO still held — no more flush-EIO per attempt.
- The hold is released + flushed on exactly three events:
  - **confirmed** (`spdk_lvs_set_leader(true)`): held ops execute in order;
  - **writer-conflict demotion**: ops abort behind the ports the conflict path blocked;
  - **retry budget exhausted**: new `spdk_lvs_promotion_give_up()` blocks the LVS data port and rejects the hublvol port **first** (mirroring the conflict demotion sequence, incl. the 10 s rule-removal poller), then fails the queues behind the block — initiators see a path drop and retry elsewhere, never a device error.
- Hardening for conflict-during-promotion: late completions of a cancelled update no longer re-claim leadership or trip the `timeout_trigger` abort; a cancelled candidate's `pending_update_lvols` are drained via `spdk_blob_update_failed_cleanup` (releasing their `blob_freeze_on_failover` refs, preventing double TAILQ insert on the next promotion).

## Expected behavior change

Failover of an LVS primary under load: clients see a ~1-2 s latency blip (IO held) instead of EIO. If promotion cannot complete (conflict, wedged JC), IO fails **behind blocked ports** -> multipath path-down semantics instead of non-retryable device errors.

## Status / review notes

- **UNTESTED — authored on a non-build host.** Needs compile + CI, and a failover soak: graceful shutdown of an LVS primary with saturated tertiary redirect traffic (the 64-pod scale-break scenario) plus the standard single/dual outage suites.
- Reviewers should check: (a) thread context of `spdk_lvs_promotion_give_up` (called from the failover cpl on the md thread; `block_port` uses `system()` — same as the existing conflict path); (b) `bs_flush_held_io_channel` op-skip condition for still-frozen blobs; (c) interaction with `spdk_lvs_nonleader_timeout`'s residual `spdk_bs_set_leader(true)` side effect (left in place; harmless under the hold, but could be removed for clarity).
- Base: `R26.2-PRE` (traced branch). If `main-latest` builds from a different branch, cherry-pick both commits there — the touched functions are identical modulo small line offsets.

Full incident analysis: `sbcli/k8s_scale_break_rca_validation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
