### PR TITLE
bdev/nvme: fail I/O over to another path on generic errors

### DIFF
--- a/module/bdev/nvme/bdev_nvme.c
+++ b/module/bdev/nvme/bdev_nvme.c
@@ -122,8 +122,21 @@ struct nvme_bdev_io {
 	/** Keeps track if first of fused commands was completed */
 	bool first_fused_completed;
 
-	/* How many times the current I/O was retried. */
+	/* How many times the current I/O was retried on the same path. */
 	int32_t retry_count;
+
+	/* How many times the current I/O was failed over to a different path
+	 * because of a non-path (generic) error. Bounded by the number of
+	 * io_paths so that a deterministic error still terminates. This is
+	 * counted separately from retry_count so that failing over does not
+	 * consume the same-path retry budget (bdev_retry_count).
+	 */
+	int32_t path_failover_count;
+
+	/* On a failover retry, the io_path that just failed this I/O; the next
+	 * path selection avoids it if another path is available.
+	 */
+	struct nvme_io_path *io_path_to_avoid;
 
 	/** Expiration value in ticks to retry the current I/O. */
 	uint64_t retry_ticks;
@@ -1150,12 +1163,13 @@ static struct nvme_io_path *
 _bdev_nvme_find_io_path(struct nvme_bdev_channel *nbdev_ch)
 {
 	struct nvme_io_path *io_path, *start, *non_optimized = NULL;
+	struct nvme_io_path *avoid = nbdev_ch->io_path_to_avoid;
 
 	start = nvme_io_path_get_next(nbdev_ch, nbdev_ch->current_io_path);
 
 	io_path = start;
 	do {
-		if (spdk_likely(nvme_io_path_is_available(io_path))) {
+		if (spdk_likely(nvme_io_path_is_available(io_path)) && io_path != avoid) {
 			switch (io_path->nvme_ns->ana_state) {
 			case SPDK_NVME_ANA_OPTIMIZED_STATE:
 				nbdev_ch->current_io_path = io_path;
@@ -1172,6 +1186,18 @@ _bdev_nvme_find_io_path(struct nvme_bdev_channel *nbdev_ch)
 		}
 		io_path = nvme_io_path_get_next(nbdev_ch, io_path);
 	} while (io_path != start);
+
+	/* On a failover retry we skip the path that just failed the I/O. If it
+	 * turns out to be the only usable path, fall back to it rather than
+	 * failing the I/O outright.
+	 */
+	if (non_optimized == NULL && avoid != NULL && nvme_io_path_is_available(avoid)) {
+		if (nbdev_ch->mp_policy == BDEV_NVME_MP_POLICY_ACTIVE_PASSIVE ||
+		    avoid->nvme_ns->ana_state == SPDK_NVME_ANA_OPTIMIZED_STATE) {
+			nbdev_ch->current_io_path = avoid;
+		}
+		return avoid;
+	}
 
 	if (nbdev_ch->mp_policy == BDEV_NVME_MP_POLICY_ACTIVE_ACTIVE) {
 		/* We come here only if there is no optimized path. Cache even non_optimized
@@ -1277,6 +1303,41 @@ any_io_path_may_become_available(struct nvme_bdev_channel *nbdev_ch)
 
 		if (nvme_qpair_is_connected(io_path->qpair) ||
 		    !nvme_ctrlr_is_failed(io_path->qpair->ctrlr)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/* Total number of io_paths in the channel (regardless of current state). Used
+ * only to bound the number of failover attempts for a single I/O.
+ */
+static uint32_t
+bdev_nvme_num_io_paths(struct nvme_bdev_channel *nbdev_ch)
+{
+	struct nvme_io_path *io_path;
+	uint32_t num = 0;
+
+	STAILQ_FOREACH(io_path, &nbdev_ch->io_path_list, stailq) {
+		num++;
+	}
+
+	return num;
+}
+
+/* Return true if there is an available io_path other than "except". */
+static bool
+bdev_nvme_another_io_path_is_available(struct nvme_bdev_channel *nbdev_ch,
+				       struct nvme_io_path *except)
+{
+	struct nvme_io_path *io_path;
+
+	STAILQ_FOREACH(io_path, &nbdev_ch->io_path_list, stailq) {
+		if (io_path == except) {
+			continue;
+		}
+		if (nvme_io_path_is_available(io_path)) {
 			return true;
 		}
 	}
@@ -1537,6 +1598,34 @@ bdev_nvme_check_retry_io(struct nvme_bdev_io *bio,
 			return false;
 		}
 		*_delay_ms = 0;
+	} else if (bio->path_failover_count < bdev_nvme_num_io_paths(nbdev_ch) &&
+		   bdev_nvme_another_io_path_is_available(nbdev_ch, io_path)) {
+		/*
+		 * A non-path (generic) error was returned on a path whose qpair and
+		 * controller still look healthy, so it did not match the path-error
+		 * checks above. In a multipath configuration where each path leads to
+		 * an independent controller, such an error is frequently specific to
+		 * this path/controller while other paths are healthy (e.g. the target
+		 * node is failing but its connection has not been torn down yet).
+		 *
+		 * Fail the I/O over to a different path instead of retrying on the
+		 * same, possibly-dying path. Crucially this is counted against
+		 * path_failover_count, not retry_count, so that dead-end attempts do
+		 * not consume the same-path retry budget (bdev_retry_count) that the
+		 * failover itself also relies on.
+		 *
+		 * The number of failovers is bounded by the number of io_paths and we
+		 * only fail over while a *different* path is available, so a genuinely
+		 * deterministic error (e.g. a media error returned identically by every
+		 * path) still terminates: once every path has been tried the I/O falls
+		 * through to the same-path retry branch below and is eventually
+		 * reported to the upper layer.
+		 */
+		bio->path_failover_count++;
+		bio->io_path_to_avoid = io_path;
+		bdev_nvme_clear_current_io_path(nbdev_ch);
+		bio->io_path = NULL;
+		*_delay_ms = 0;
 	} else {
 		bio->retry_count++;
 
@@ -1592,6 +1681,8 @@ bdev_nvme_io_complete_nvme_status(struct nvme_bdev_io *bio,
 
 complete:
 	bio->retry_count = 0;
+	bio->path_failover_count = 0;
+	bio->io_path_to_avoid = NULL;
 	bio->submit_tsc = 0;
 	bdev_io->u.bdev.accel_sequence = NULL;
 	__bdev_nvme_io_complete(bdev_io, 0, cpl);
@@ -1635,6 +1726,8 @@ bdev_nvme_io_complete(struct nvme_bdev_io *bio, int rc)
 	}
 
 	bio->retry_count = 0;
+	bio->path_failover_count = 0;
+	bio->io_path_to_avoid = NULL;
 	bio->submit_tsc = 0;
 	__bdev_nvme_io_complete(bdev_io, io_status, NULL);
 }
@@ -3455,7 +3548,12 @@ bdev_nvme_submit_request(struct spdk_io_channel *ch, struct spdk_bdev_io *bdev_i
 	}
 
 	spdk_trace_record(TRACE_BDEV_NVME_IO_START, 0, 0, (uintptr_t)nbdev_io, (uintptr_t)bdev_io);
+	/* Publish the failover skip hint for the duration of this synchronous
+	 * path selection only, then clear it so it cannot affect other I/Os.
+	 */
+	nbdev_ch->io_path_to_avoid = nbdev_io->io_path_to_avoid;
 	nbdev_io->io_path = bdev_nvme_find_io_path(nbdev_ch);
+	nbdev_ch->io_path_to_avoid = NULL;
 	if (spdk_unlikely(!nbdev_io->io_path)) {
 		if (!bdev_nvme_io_type_is_admin(bdev_io->type)) {
 			bdev_nvme_io_complete(nbdev_io, -ENXIO);

--- a/module/bdev/nvme/bdev_nvme.h
+++ b/module/bdev/nvme/bdev_nvme.h
@@ -208,6 +208,13 @@ struct nvme_io_path {
 
 struct nvme_bdev_channel {
 	struct nvme_io_path			*current_io_path;
+	/* Transient hint, set only for the duration of a single (synchronous)
+	 * path selection during a failover retry: the io_path that just failed
+	 * the I/O and should be skipped if any other path is available. It is
+	 * consumed and cleared by _bdev_nvme_find_io_path(). Never dereferenced
+	 * outside that synchronous window.
+	 */
+	struct nvme_io_path			*io_path_to_avoid;
 	enum spdk_bdev_nvme_multipath_policy	mp_policy;
 	enum spdk_bdev_nvme_multipath_selector	mp_selector;
 	uint32_t				rr_min_io;


### PR DESCRIPTION
## bdev/nvme: fail I/O over to another path on generic errors

### Problem

In a multipath setup where each path leads to an **independent controller** (primary / secondary / tertiary over a distributed backend), an I/O can complete with a **non-path (generic) NVMe error** on a path whose qpair and controller still look healthy — the completion arrives *before* the qpair is torn down, so it is not classified as a path error.

`bdev_nvme_check_retry_io()` handled this in its `else` branch by **retrying on the same path** and charging the attempt against the shared `bdev_retry_count` budget (default **3**).

The reroute decision hinges entirely on `spdk_nvme_cpl_is_path_error()`, which is just `status.sct == SPDK_NVME_SCT_PATH`. A path that is dying but reports a *generic* status (and whose qpair/ctrlr liveness flags have not flipped yet) never trips that check, so:

- the same-path retries **burn the very budget the cross-path failover also needs** — both `bdev_nvme_io_complete_nvme_status()` (give-up) and the `-ENXIO` reroute in `bdev_nvme_io_complete()` gate on `retry_count < bdev_retry_count`;
- with a fast-failing dead path, `retry_count` reaches `bdev_retry_count` **before** the controller reset marks the qpair down;
- the I/O is failed upward even though a healthy alternate path existed the whole time.

Observed in a tertiary (`lvs_31`) hub-lvol topology: one I/O landed on the primary connection to a node that had just gone offline, completed in failure before the qpair was destroyed, triggered a controller reset, and was aborted upward instead of being retried on the healthy secondary.

### Fix

Add a bounded, path-aware failover branch to `bdev_nvme_check_retry_io()`:

1. **Reroute instead of same-path retry.** On a retryable non-path error, if a *different* `io_path` is available, fail the I/O over to it.
2. **Separate accounting.** Failovers are counted against a new per-I/O `path_failover_count`, **not** `retry_count`, so dead-end attempts no longer consume the same-path retry budget.
3. **Skip the failed path.** `io_path_to_avoid` is honored by `_bdev_nvme_find_io_path()` for exactly one (synchronous) selection — otherwise active-passive would just re-pick the same still-"available" path and never reach the alternate. If the avoided path turns out to be the only usable one, it falls back to it rather than failing the I/O.
4. **Termination guaranteed.** The number of failovers is bounded by the number of `io_path`s, and we only fail over while another path is available. A genuinely deterministic error (e.g. a media error returned identically by every path) still terminates: once every path has been tried the I/O falls through to the existing same-path retry branch and is reported upward as before.

### Safety / scope

- **Single-path configs are unaffected** — with no other available path the failover branch is skipped; behavior is byte-for-byte identical to before. Also covers `DNR` / aborted-by-request / accel-sequence (still filtered by the caller) and hard path errors (unchanged branch).
- The **min_qd (queue-depth) selector is intentionally left unchanged**; it already balances by outstanding-request count and the reported issue is specific to active-passive / round-robin.
- `io_path_to_avoid` on the channel is a **transient hint**, set and cleared around a single synchronous `find_io_path()` call in `bdev_nvme_submit_request()`, so it can never leak into another I/O's selection.

### Files

- `module/bdev/nvme/bdev_nvme.h` — transient `io_path_to_avoid` on `nvme_bdev_channel`.
- `module/bdev/nvme/bdev_nvme.c` — `path_failover_count` + `io_path_to_avoid` on `nvme_bdev_io`; `bdev_nvme_num_io_paths()` / `bdev_nvme_another_io_path_is_available()` helpers; skip logic in `_bdev_nvme_find_io_path()`; failover branch in `bdev_nvme_check_retry_io()`; hint plumbing in `bdev_nvme_submit_request()`; field resets on completion.

### Testing

- [ ] Build (`make` in a Linux SPDK tree) — not run in the authoring environment.
- [ ] `test/unit/lib/bdev/nvme/bdev_nvme.c/bdev_nvme_ut` — the existing "generic error retries on the same path with two paths" expectations will change and need updating to assert failover + counter separation.
- [ ] Reproduce the incident: two paths to independent controllers, active-passive, take the active path's node offline mid-I/O, confirm outstanding I/O fails over to the peer instead of being aborted upward, and that `bdev_retry_count` is not exhausted by the dead path.
